### PR TITLE
Добавлены мета-теги для Twitter cards + исправлены og-теги

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,7 @@
   <meta property="og:title" content="Веблайнд — рекомендации по разработке сайтов для людей с нарушениями зрения">
   <meta property="og:description" content="В России 880 тысяч слепых и слабовидящих. Наши рекомендации помогут разработчикам делать сайты, удобные для людей с нарушениями зрения.">
   <meta property="og:image" content="https://weblind.ru/images/share.png">
+  <meta property="og:image:alt" content="Как помочь слепым на вашем сайте">
   <meta name="twitter:card" content="summary_large_image">
   <meta property="twitter:title" content="Рекомендации по разработке сайтов для людей с нарушениями зрения">
   <meta property="twitter:description" content="В России 880 тысяч слепых и слабовидящих. Наши рекомендации помогут разработчикам делать сайты, удобные для людей с нарушениями зрения.">

--- a/src/index.html
+++ b/src/index.html
@@ -3,8 +3,12 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta property="og:url" content="https://weblind.ru/">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Веблайнд">
   <meta property="og:title" content="Веблайнд — рекомендации по разработке сайтов для людей с нарушениями зрения">
-  <meta property="og:image" content="http://weblind.ru/images/share.png">
+  <meta property="og:description" content="В России 880 тысяч слепых и слабовидящих. Наши рекомендации помогут разработчикам делать сайты, удобные для людей с нарушениями зрения.">
+  <meta property="og:image" content="https://weblind.ru/images/share.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta property="twitter:title" content="Рекомендации по разработке сайтов для людей с нарушениями зрения">
   <meta property="twitter:description" content="В России 880 тысяч слепых и слабовидящих. Наши рекомендации помогут разработчикам делать сайты, удобные для людей с нарушениями зрения.">

--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:title" content="Веблайнд — рекомендации по разработке сайтов для людей с нарушениями зрения">
   <meta property="og:image" content="http://weblind.ru/images/share.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta property="twitter:title" content="Рекомендации по разработке сайтов для людей с нарушениями зрения">
+  <meta property="twitter:description" content="В России 880 тысяч слепых и слабовидящих. Наши рекомендации помогут разработчикам делать сайты, удобные для людей с нарушениями зрения.">
+  <meta property="twitter:image" content="https://weblind.ru/images/share.png">
+  <meta property="twitter:image:alt" content="Как помочь слепым на вашем сайте">
   <link rel="icon" href="images/favicon.ico">
   <link rel="apple-touch-icon" href="images/iphone-icon.png">
 
@@ -224,7 +229,7 @@
                   для людей с нарушениями зрения. Они основаны на официальных источниках — <nobr>ГОСТ
                   <a href="http://www.internet-law.ru/gosts/gost/54797/">Р 52872-2012</a></nobr>, руководство
                   <a href="https://www.w3.org/Translations/WCAG20-ru/">WCAG 2.0</a> от W3C и
-                  <a href="https://www.access-board.gov/sec508/508standards.pdf">Section 508</a>. 
+                  <a href="https://www.access-board.gov/sec508/508standards.pdf">Section 508</a>.
                   Способы, описанные в рекомендациях, не влияют на внешний вид сайта и не мешают работе пользователей с нормальным зрением.
                 </p>
               </div>

--- a/src/inner.html
+++ b/src/inner.html
@@ -9,6 +9,7 @@
   <meta property="og:title" content="Веблайнд — рекомендации по разработке сайтов для людей с нарушениями зрения">
   <meta property="og:description" content="В России 880 тысяч слепых и слабовидящих. Наши рекомендации помогут разработчикам делать сайты, удобные для людей с нарушениями зрения.">
   <meta property="og:image" content="https://weblind.ru/images/share.png">
+  <meta property="og:image:alt" content="Как помочь слепым на вашем сайте">
   <meta name="twitter:card" content="summary_large_image">
   <meta property="twitter:title" content="Рекомендации по разработке сайтов для людей с нарушениями зрения">
   <meta property="twitter:description" content="В России 880 тысяч слепых и слабовидящих. Наши рекомендации помогут разработчикам делать сайты, удобные для людей с нарушениями зрения.">

--- a/src/inner.html
+++ b/src/inner.html
@@ -3,8 +3,12 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta property="og:url" content="https://weblind.ru/inner.html">
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="Веблайнд">
   <meta property="og:title" content="Веблайнд — рекомендации по разработке сайтов для людей с нарушениями зрения">
-  <meta property="og:image" content="http://weblind.ru/images/share.png">
+  <meta property="og:description" content="В России 880 тысяч слепых и слабовидящих. Наши рекомендации помогут разработчикам делать сайты, удобные для людей с нарушениями зрения.">
+  <meta property="og:image" content="https://weblind.ru/images/share.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta property="twitter:title" content="Рекомендации по разработке сайтов для людей с нарушениями зрения">
   <meta property="twitter:description" content="В России 880 тысяч слепых и слабовидящих. Наши рекомендации помогут разработчикам делать сайты, удобные для людей с нарушениями зрения.">

--- a/src/inner.html
+++ b/src/inner.html
@@ -5,6 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:title" content="Веблайнд — рекомендации по разработке сайтов для людей с нарушениями зрения">
   <meta property="og:image" content="http://weblind.ru/images/share.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta property="twitter:title" content="Рекомендации по разработке сайтов для людей с нарушениями зрения">
+  <meta property="twitter:description" content="В России 880 тысяч слепых и слабовидящих. Наши рекомендации помогут разработчикам делать сайты, удобные для людей с нарушениями зрения.">
+  <meta property="twitter:image" content="https://weblind.ru/images/share.png">
+  <meta property="twitter:image:alt" content="Как помочь слепым на вашем сайте">
   <link rel="icon" href="images/favicon.ico">
   <link rel="apple-touch-icon" href="images/iphone-icon.png">
 


### PR DESCRIPTION
Суть изменений:
1. в текущей версии разметки нет тегов для Тwitter cards. Я добавил её;
2. поправил ошибки, которые показывал дебаггер open graph разметки от Фейсбука;
3. поменял схему ссылки в og:image на https (т.к. сам сайт использует именно его) и добавил для неё альтернативный текст.
