### PR TITLE
Исправляет некорректный caption в примере кода

### DIFF
--- a/src/inner.html
+++ b/src/inner.html
@@ -1232,7 +1232,7 @@
                           </div>
 
                           <div>
-<pre><code><span class="example-select">&lt;caption&gt;Расписание работы магазина&lt;/caption&gt;</span>
+<pre><code><span class="example-select">&lt;caption&gt;Участники проекта «Курьер»&lt;/caption&gt;</span>
 &lt;thead&gt;
   &lt;tr&gt;
     &lt;th <span class="example-select">scope="col"</span>&gt;№ строки&lt;/th&gt;


### PR DESCRIPTION
В пример кода с таблицами, видимо, попал caption из другого примера. Привела его в соответствие коду.