### PR TITLE
Исправляет использованный тег на `<td>` в примере с таблицами

### DIFF
--- a/src/inner.html
+++ b/src/inner.html
@@ -1244,9 +1244,9 @@
 &lt;tbody&gt;
   &lt;tr&gt;
     &lt;th <span class="example-select">scope="row"</span>&gt;1&lt;/th&gt;
-    &lt;th&gt;Иванов Александр Александрович&lt;/th&gt;
-    &lt;th&gt;23 года&lt;/th&gt;
-    &lt;th&gt;Врач&lt;/th&gt;
+    &lt;td&gt;Иванов Александр Александрович&lt;/td&gt;
+    &lt;td&gt;23 года&lt;/td&gt;
+    &lt;td&gt;Врач&lt;/td&gt;
   &lt;/tr&gt;
 &lt;/tbody&gt;</code></pre>
                           </div>


### PR DESCRIPTION
Синхронизация примера и разметки таблицы выше, раньше они разнились 🙂

<img width="692" alt="«Screenshot» 2021-05-20 at 14 46 28" src="https://user-images.githubusercontent.com/9102374/118973299-328a3880-b97a-11eb-90ce-9f356274abf8.png">
