### PR TITLE
Правит ссылку

### DIFF
--- a/src/inner.html
+++ b/src/inner.html
@@ -1614,10 +1614,10 @@
                             <nav>
                               <ul class="menu-h">
                                 <li class="level-1 active" aria-current="page">
-                                  <span><a href="#">Шапки, шарфы, варежки</a></span>
+                                  <span><a>Шапки, шарфы, варежки</a></span>
                                 </li>
-                                <li class="level-1"><span><a href="#">Цены</a></span></li>
-                                <li class="level-1"><span><a href="#">Контакты</a></span></li>
+                                <li class="level-1"><span><a>Цены</a></span></li>
+                                <li class="level-1"><span><a>Контакты</a></span></li>
                               </ul>
                             </nav>
                           </div>

--- a/src/inner.html
+++ b/src/inner.html
@@ -1611,13 +1611,13 @@
                         <div class="example">
                           <h5>Пример</h5>
                           <div class="padding-bottom-20">
-                            <nav>
+                            <nav id="nav-menu">
                               <ul class="menu-h">
                                 <li class="level-1 active" aria-current="page">
-                                  <span><a>Шапки, шарфы, варежки</a></span>
+                                  <span><a href="#nav-menu">Шапки, шарфы, варежки</a></span>
                                 </li>
-                                <li class="level-1"><span><a>Цены</a></span></li>
-                                <li class="level-1"><span><a>Контакты</a></span></li>
+                                <li class="level-1"><span><a href="#nav-menu">Цены</a></span></li>
+                                <li class="level-1"><span><a href="#nav-menu">Контакты</a></span></li>
                               </ul>
                             </nav>
                           </div>


### PR DESCRIPTION
https://weblind.ru/inner.html#nav-menu

Если кликнуть на любой пример в меню «Шапки», «Цены», «Контакты», то сваливаешься не на https://weblind.ru/inner.html даже, а на https://weblind.ru и это несколько озадачивает. 

Стандарт, кажется, тоже [разрешает](https://www.w3.org/TR/html52/textlevel-semantics.html#the-a-element) ссылки без `href=""`

